### PR TITLE
14 listed data card

### DIFF
--- a/src/app/(pages)/layout.tsx
+++ b/src/app/(pages)/layout.tsx
@@ -4,7 +4,6 @@ import '@/globals.css';
 import Header from '@/components/header/Header';
 
 const inter = Inter({
-  weight: '600',
   subsets: ['latin'],
   variable: '--font-sans',
 });

--- a/src/app/components/data-lists/LabeledValueCard.tsx
+++ b/src/app/components/data-lists/LabeledValueCard.tsx
@@ -9,24 +9,30 @@ type LabeledValues = {
 };
 
 type LabeledValueCardProps = Omit<JSX.IntrinsicElements['div'], 'ref'> & {
-  icon?: LucideIcon;
+  titleIcon?: LucideIcon;
   title: string;
   values: LabeledValues[];
 };
 
-export default function LabeledValueCard({ icon: Icon, title, values, className, ...props }: LabeledValueCardProps) {
+export default function LabeledValueCard({
+  titleIcon: TitleIcon,
+  title,
+  values,
+  className,
+  ...props
+}: LabeledValueCardProps) {
   return (
-    <Card className={cn('', className)} {...props}>
+    <Card className={className} {...props}>
       <CardHeader>
-        <CardTitle>
-          <span>{Icon && <Icon width={30} height={30} />}</span>
+        <CardTitle className="flex items-center gap-3">
+          <span>{TitleIcon && <TitleIcon width={30} height={30} />}</span>
           <span>{title}</span>
         </CardTitle>
       </CardHeader>
       {values.map(({ label: l, value: v }) => (
         <CardContent key={l}>
-          <p className="text-readable-gray">{l}</p>
-          <p className="font-semibold">{v}</p>
+          <p className="text-2xl text-readable-gray">{l}</p>
+          <p className="text-2xl font-semibold">{v}</p>
         </CardContent>
       ))}
     </Card>

--- a/src/app/components/data-lists/LabeledValueCard.tsx
+++ b/src/app/components/data-lists/LabeledValueCard.tsx
@@ -39,15 +39,11 @@ function NestedValues({ values }: { values: LabeledValues[] }) {
   return (
     <>
       {values.map(({ label: l, value: v }) => (
-        <CardContent key={l}>
+        <CardContent className="py-1" key={l}>
           <p className="text-2xl text-readable-gray">{l}</p>
-          {v.kind === 'leaf' && (
-            <p className="relative text-2xl font-semibold after:absolute after:-left-6 after:top-0 after:h-1/6 after:w-4 after:border-b-2 after:bg-transparent after:content-['']">
-              {v.node}
-            </p>
-          )}
+          {v.kind === 'leaf' && <p className="relative text-2xl font-semibold">{v.node}</p>}
           {v.kind === 'nested' && (
-            <div className="ml-2 border-l-2 border-light-gray">
+            <div className="border-l-2 border-light-gray">
               <NestedValues values={v.values} />
             </div>
           )}

--- a/src/app/components/data-lists/LabeledValueCard.tsx
+++ b/src/app/components/data-lists/LabeledValueCard.tsx
@@ -88,6 +88,12 @@ function NestedValues({ values, root }: { values: LabeledValues[]; root?: boolea
   );
 }
 
+/**
+ * Component to display a json/Record like structure.
+ * Nested values will also be displayed with an indent.
+ * Helper functions have been defined to facilitate
+ * adding labeled values.
+ */
 export default function LabeledValueCard({
   titleIcon: TitleIcon,
   title,
@@ -98,7 +104,7 @@ export default function LabeledValueCard({
   return (
     <Card className={className} {...props}>
       <CardHeader>
-        <CardTitle className="flex items-center gap-3">
+        <CardTitle className={cn('flex items-center', TitleIcon && 'gap-3')}>
           <span>{TitleIcon && <TitleIcon width={30} height={30} />}</span>
           <span>{title}</span>
         </CardTitle>

--- a/src/app/components/data-lists/LabeledValueCard.tsx
+++ b/src/app/components/data-lists/LabeledValueCard.tsx
@@ -1,0 +1,34 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/shadcn/card';
+import { cn } from '@/utils/styling';
+import { LucideIcon } from 'lucide-react';
+import { ReactNode } from 'react';
+
+type LabeledValues = {
+  label: string;
+  value: ReactNode;
+};
+
+type LabeledValueCardProps = Omit<JSX.IntrinsicElements['div'], 'ref'> & {
+  icon?: LucideIcon;
+  title: string;
+  values: LabeledValues[];
+};
+
+export default function LabeledValueCard({ icon: Icon, title, values, className, ...props }: LabeledValueCardProps) {
+  return (
+    <Card className={cn('', className)} {...props}>
+      <CardHeader>
+        <CardTitle>
+          <span>{Icon && <Icon width={30} height={30} />}</span>
+          <span>{title}</span>
+        </CardTitle>
+      </CardHeader>
+      {values.map(({ label: l, value: v }) => (
+        <CardContent key={l}>
+          <p className="text-readable-gray">{l}</p>
+          <p className="font-semibold">{v}</p>
+        </CardContent>
+      ))}
+    </Card>
+  );
+}

--- a/src/app/components/data-lists/LabeledValueCard.tsx
+++ b/src/app/components/data-lists/LabeledValueCard.tsx
@@ -3,9 +3,19 @@ import { cn } from '@/utils/styling';
 import { LucideIcon } from 'lucide-react';
 import { ReactNode } from 'react';
 
+type LeafNode = {
+  kind: 'leaf';
+  node: ReactNode;
+};
+
+type NestedNodes = {
+  kind: 'nested';
+  values: LabeledValues[];
+};
+
 type LabeledValues = {
   label: string;
-  value: ReactNode;
+  value: LeafNode | NestedNodes;
 };
 
 type LabeledValueCardProps = Omit<JSX.IntrinsicElements['div'], 'ref'> & {
@@ -13,6 +23,39 @@ type LabeledValueCardProps = Omit<JSX.IntrinsicElements['div'], 'ref'> & {
   title: string;
   values: LabeledValues[];
 };
+
+export function node(value: ReactNode): LeafNode {
+  return { kind: 'leaf', node: value };
+}
+
+export function nested(values: LabeledValues[]): NestedNodes {
+  return { kind: 'nested', values: values };
+}
+
+/**
+ * Recursive labels and values that indents new labeled values
+ */
+function NestedValues({ values }: { values: LabeledValues[] }) {
+  return (
+    <>
+      {values.map(({ label: l, value: v }) => (
+        <CardContent key={l}>
+          <p className="text-2xl text-readable-gray">{l}</p>
+          {v.kind === 'leaf' && (
+            <p className="relative text-2xl font-semibold after:absolute after:-left-6 after:top-0 after:h-1/6 after:w-4 after:border-b-2 after:bg-transparent after:content-['']">
+              {v.node}
+            </p>
+          )}
+          {v.kind === 'nested' && (
+            <div className="ml-2 border-l-2 border-light-gray">
+              <NestedValues values={v.values} />
+            </div>
+          )}
+        </CardContent>
+      ))}
+    </>
+  );
+}
 
 export default function LabeledValueCard({
   titleIcon: TitleIcon,
@@ -29,12 +72,7 @@ export default function LabeledValueCard({
           <span>{title}</span>
         </CardTitle>
       </CardHeader>
-      {values.map(({ label: l, value: v }) => (
-        <CardContent key={l}>
-          <p className="text-2xl text-readable-gray">{l}</p>
-          <p className="text-2xl font-semibold">{v}</p>
-        </CardContent>
-      ))}
+      <NestedValues values={values} />
     </Card>
   );
 }

--- a/src/app/components/shadcn/card.tsx
+++ b/src/app/components/shadcn/card.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+
+import { cn } from '@/utils/styling';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50',
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  ),
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-2xl font-semibold leading-none tracking-tight', className)} {...props} />
+  ),
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-slate-500 dark:text-slate-400', className)} {...props} />
+  ),
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />,
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  ),
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/app/components/shadcn/card.tsx
+++ b/src/app/components/shadcn/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   <div
     ref={ref}
     className={cn(
-      'rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50',
+      'rounded-lg border border-slate-200 bg-white pb-6 text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50',
       className,
     )}
     {...props}

--- a/src/app/components/shadcn/card.tsx
+++ b/src/app/components/shadcn/card.tsx
@@ -36,7 +36,7 @@ const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttribu
 CardDescription.displayName = 'CardDescription';
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />,
+  ({ className, ...props }, ref) => <div ref={ref} className={cn('p-6 py-2', className)} {...props} />,
 );
 CardContent.displayName = 'CardContent';
 

--- a/src/app/components/shadcn/card.tsx
+++ b/src/app/components/shadcn/card.tsx
@@ -23,7 +23,7 @@ CardHeader.displayName = 'CardHeader';
 
 const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn('text-2xl font-semibold leading-none tracking-tight', className)} {...props} />
+    <h3 ref={ref} className={cn('text-2xl font-bold leading-none tracking-tight', className)} {...props} />
   ),
 );
 CardTitle.displayName = 'CardTitle';

--- a/src/stories/data-lists/LabeledValueCard.stories.ts
+++ b/src/stories/data-lists/LabeledValueCard.stories.ts
@@ -1,0 +1,36 @@
+import LabeledValueCard from '@/components/data-lists/LabeledValueCard';
+import type { Meta, StoryObj } from '@storybook/react';
+import { CircleUser } from 'lucide-react';
+
+const meta = {
+  title: 'DataLists/LabeledValueCard',
+  component: LabeledValueCard,
+  tags: ['autodocs'],
+} satisfies Meta<typeof LabeledValueCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    titleIcon: CircleUser,
+    title: 'Subject',
+    values: [
+      {
+        label: 'Name',
+        value: 'Person A',
+      },
+      {
+        label: 'ID',
+        value: 'Identifier A',
+      },
+    ],
+  },
+};
+
+export const NoValues: Story = {
+  args: {
+    title: 'Issuer',
+    values: [],
+  },
+};

--- a/src/stories/data-lists/LabeledValueCard.stories.ts
+++ b/src/stories/data-lists/LabeledValueCard.stories.ts
@@ -1,6 +1,6 @@
-import LabeledValueCard from '@/components/data-lists/LabeledValueCard';
+import LabeledValueCard, { nested, node } from '@/components/data-lists/LabeledValueCard';
 import type { Meta, StoryObj } from '@storybook/react';
-import { CircleUser } from 'lucide-react';
+import { CircleUser, FilePenLine } from 'lucide-react';
 
 const meta = {
   title: 'DataLists/LabeledValueCard',
@@ -18,11 +18,11 @@ export const Default: Story = {
     values: [
       {
         label: 'Name',
-        value: 'Person A',
+        value: node('Identifier A'),
       },
       {
         label: 'ID',
-        value: 'Identifier A',
+        value: node('123456'),
       },
     ],
   },
@@ -30,7 +30,56 @@ export const Default: Story = {
 
 export const NoValues: Story = {
   args: {
+    titleIcon: FilePenLine,
     title: 'Issuer',
     values: [],
+  },
+};
+
+export const TwiceNested: Story = {
+  args: {
+    titleIcon: CircleUser,
+    title: 'Subject',
+    values: [
+      {
+        label: 'Name',
+        value: node('Bob'),
+      },
+      {
+        label: 'Degree',
+        value: nested([
+          {
+            label: 'Type',
+            value: node('Bachelor of Science'),
+          },
+          {
+            label: 'Study',
+            value: node('Computer Science'),
+          },
+        ]),
+      },
+      {
+        label: 'Driving licence',
+        value: nested([
+          {
+            label: 'Class',
+            value: node('B'),
+          },
+          {
+            label: 'Information',
+            value: nested([
+              {
+                label: 'Issued',
+                value: node('2015-01-01'),
+              },
+              {
+                label: 'Expires',
+                value: node('2025-01-01'),
+              },
+            ]),
+          },
+        ]),
+      },
+    ],
   },
 };

--- a/src/stories/data-lists/LabeledValueCard.stories.ts
+++ b/src/stories/data-lists/LabeledValueCard.stories.ts
@@ -1,4 +1,4 @@
-import LabeledValueCard, { nested, node } from '@/components/data-lists/LabeledValueCard';
+import LabeledValueCard, { fromJSON, nested, node } from '@/components/data-lists/LabeledValueCard';
 import type { Meta, StoryObj } from '@storybook/react';
 import { CircleUser, FilePenLine } from 'lucide-react';
 
@@ -81,5 +81,26 @@ export const TwiceNested: Story = {
         ]),
       },
     ],
+  },
+};
+
+export const FromJSON: Story = {
+  args: {
+    titleIcon: CircleUser,
+    title: 'Subject',
+    values: fromJSON({
+      Name: 'Bob',
+      Degree: {
+        Type: 'Bachelor of Science',
+        Study: 'Computer Science',
+      },
+      'Driving licence': {
+        Class: 'B',
+        Information: {
+          Issued: '2015-01-01',
+          Expires: '2025-01-01',
+        },
+      },
+    }),
   },
 };


### PR DESCRIPTION
partially closes  #14

## Proposed changes
Uses the shadcn card component to display records according to the figma design. As verifiable credential subjects might have nested values, it is possible to add nested data to the card. Helper functions have been created to easier add new information.

## Screenshots
![image](https://github.com/thomsen85/vc-inspector/assets/70779496/71352ad3-6b38-474f-bc23-f361b304c7f1)
![image](https://github.com/thomsen85/vc-inspector/assets/70779496/f9b4a12a-ab98-477f-8976-58c77ec94383)


## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added
- [x] Documentation have been written
